### PR TITLE
fix: category counts shown on home (preserve FS counts in merge), tag…

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,19 +20,23 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.8,
   }));
 
-  const categoryUrls = categories.map((category) => ({
-    url: `${SITE_URL}/blog/category/${category.slug}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.6,
-  }));
+  const categoryUrls = categories
+    .filter((category) => category.count > 0)
+    .map((category) => ({
+      url: `${SITE_URL}/blog/category/${category.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    }));
 
-  const tagUrls = tags.map((tag) => ({
-    url: `${SITE_URL}/blog/tag/${tag.slug}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.5,
-  }));
+  const tagUrls = tags
+    .filter((tag) => tag.count >= 3)
+    .map((tag) => ({
+      url: `${SITE_URL}/blog/tag/${tag.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.5,
+    }));
 
   const archiveUrls = archives.map((archive) => ({
     url: `${SITE_URL}/blog/archive/${archive.year}`,

--- a/lib/blog/seo.ts
+++ b/lib/blog/seo.ts
@@ -106,10 +106,12 @@ export function generateCategoryMetadata(category: Category): Metadata {
 }
 
 function isValuableTag(tag: Tag): boolean {
-  // A tag page is considered valuable for indexing when it has enough
-  // posts and a unique description. Otherwise it is treated as a thin
-  // duplicate archive and marked noindex,follow.
-  return tag.count >= 3 && !!tag.description?.trim();
+  // A tag page is considered valuable for indexing when it has enough posts.
+  // The description field is optional metadata used to enrich the meta tag
+  // when present, but it is not required for indexing.
+  // Tags with fewer than 3 posts are treated as thin duplicate archives and
+  // marked noindex,follow.
+  return tag.count >= 3;
 }
 
 export function generateTagMetadata(tag: Tag): Metadata {

--- a/lib/content/composite-source.ts
+++ b/lib/content/composite-source.ts
@@ -269,7 +269,7 @@ function mergeCategoryCounts(
   db: NormalizedCategory[] | undefined
 ): NormalizedCategory[] {
   const map = new Map<string, NormalizedCategory>();
-  for (const c of fs) map.set(c.slug, { ...c, count: 0 });
+  for (const c of fs) map.set(c.slug, { ...c }); // start with FS counts intact
   if (db) {
     for (const c of db) {
       const existing = map.get(c.slug);
@@ -285,7 +285,7 @@ function mergeTagCounts(
   db: NormalizedTag[] | undefined
 ): NormalizedTag[] {
   const map = new Map<string, NormalizedTag>();
-  for (const t of fs) map.set(t.slug, { ...t, count: 0 });
+  for (const t of fs) map.set(t.slug, { ...t }); // start with FS counts intact
   if (db) {
     for (const t of db) {
       const existing = map.get(t.slug);


### PR DESCRIPTION
… noindex rule uses count>=3 only, sitemap excludes 0-count categories and <3-post tags